### PR TITLE
Add a configurable url path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ The bind address to listen for requests
 The port to listen for requests
 - **`RUST_LOG`**:
 Controls the logging level for Rust applications, allowing you to specify which logs should be shown during the execution. By setting this variable, you can adjust the verbosity of the logs for debugging or monitoring purposes.
+- **`URL_PREFIX`**:
+Optional : let you configure a prefix to all endpoints, e.g. if you set URL_PREFIX=jwtd, then a valid sign http query will look like (notice target url change) :
+    
+      curl  -d '{"aid":"AGENT:007", "huk":["r001", "r002"]}' -H "Content-Type: application/json" http://localhost:8080/jwtd/sign?generate=iat,exp,iss
+
+  "/" characters can be included or not in the env variable, because they are ignored. URL_PREFIX=/jwtd/ will have the same effect as above. Thus, url prefixes with multiple levels are not supported: URL_PREFIX=/jw/td/ will behave like URL_PREFIX=jwtd.
 
 ## Token configuration
 - **`API_KEYS`**:

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use log::warn;
 use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs8::DecodePrivateKey, PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -542,6 +543,17 @@ async fn main() {
         std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0))
     });
 
+    let url_prefix = match env::var("URL_PREFIX") {
+        Ok(mut prefix) => {
+            prefix.retain(|c| c != '/');
+            Some(prefix)
+        }
+        Err(e) => {
+            warn!("error {}", e.to_string());
+            None
+        }
+    };
+
     let routes = encrypt
         .or(decrypt)
         .or(sign)
@@ -550,7 +562,11 @@ async fn main() {
         .or(bcrypt_check);
 
     log::info!("Server starting on port {}:{}", socket_addr, port);
-    warp::serve(routes).run((socket_addr, port)).await;
+    if url_prefix.is_some() {
+        warp::serve(warp::path(url_prefix.unwrap()).and(routes)).run((socket_addr, port)).await;
+    } else {
+        warp::serve(routes).run((socket_addr, port)).await;
+        }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
-use log::warn;
+
 use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs8::DecodePrivateKey, PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -549,7 +549,7 @@ async fn main() {
             Some(prefix)
         }
         Err(e) => {
-            warn!("error {}", e.to_string());
+            log::warn!("error redaing env var {}", e.to_string());
             None
         }
     };


### PR DESCRIPTION
This will be used on env scaled with the keda http interceptor. The modification let one configure an env var URL_PREFIX that will be applied to all the service endpoints.

On trafic routed from the same host to different services, the interceptor use the url path to determine which backend service it should scale and route the traffic to. If the ingress strip the prefix to match the service expected route, the interceptor cannot know where to route the trafic anymore. To fix this we have to remove the prefix stripping in the ingress, and then make the backend service accept the prefixed route.